### PR TITLE
WIP: Feature to enable uniform behavior for unix, windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,10 @@ branch = "master"
 version = "^0.2.66"
 default-features = false
 
+[target.'cfg(unix)'.dependencies.once_cell]
+version = "^1.8.0"
+optional = true
+
 [target.'cfg(windows)'.dependencies.winapi]
 version = "^0.3.8"
 features = [
@@ -38,3 +42,4 @@ features = [
 [features]
 default = ["std"]
 std = []
+multilock = [ "std", "once_cell" ]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,14 +43,14 @@ use nil_fileid as fileid;
 /// file, by the same process, are exclusive.
 #[derive(Debug,Copy,Clone)]
 #[non_exhaustive]
-enum Exclusive {
+enum Exclusivity {
     /// Treat any two file descriptors to the same file as having
     /// separate locks.
     ///
     /// This option requires allocation internally, and is not
     /// available on Unix when building without the `std` feature.
     #[cfg(any(not(unix), feature="multilock"))]
-    ExclusiveInProcess,
+    PerFileDesc,
     /// Os-dependent behavior.
     OsDependent,
 }
@@ -334,7 +334,7 @@ impl LockFile {
     where
         P: ToOsStr + ?Sized,
     {
-        Self::open_internal(path, Exclusive::ExclusiveInProcess)
+        Self::open_internal(path, Exclusivity::PerFileDesc)
     }
 
     /// Opens a file for locking, with OS-dependent locking behavior. On Unix,
@@ -402,11 +402,11 @@ impl LockFile {
     where
         P: ToOsStr + ?Sized,
     {
-        Self::open_internal(path, Exclusive::OsDependent)
+        Self::open_internal(path, Exclusivity::OsDependent)
     }
 
     /// Implementation helper for open_excl and open.
-    fn open_internal<P>(path: &P, ex: Exclusive) -> Result<Self, Error>
+    fn open_internal<P>(path: &P, ex: Exclusivity) -> Result<Self, Error>
     where
         P: ToOsStr + ?Sized,
     {

--- a/src/nil_fileid.rs
+++ b/src/nil_fileid.rs
@@ -1,13 +1,13 @@
 
 use crate::Error;
 use crate::sys::FileDesc;
-use  crate::Exclusive;
+use  crate::Exclusivity;
 
 #[derive(Debug,Copy,Clone)]
 pub struct FileId;
 
 impl FileId {
-    pub(crate) fn get_id(_: FileDesc, _ : Exclusive) -> Result<Self, Error> {
+    pub(crate) fn get_id(_: FileDesc, _ : Exclusivity) -> Result<Self, Error> {
         Ok(FileId)
     }
     pub fn take_lock(&self) {}

--- a/src/nil_fileid.rs
+++ b/src/nil_fileid.rs
@@ -1,9 +1,16 @@
 
 use crate::Error;
 use crate::sys::FileDesc;
+use  crate::Exclusive;
 
-pub type FileId = ();
-pub fn get_id(_: FileDesc) -> Result<FileId, Error> { Ok(()) }
-pub fn take_lock(_: FileId) {}
-pub fn try_take_lock(_: FileId) -> bool { true }
-pub fn release_lock(_: FileId) {}
+#[derive(Debug,Copy,Clone)]
+pub struct FileId;
+
+impl FileId {
+    pub(crate) fn get_id(_: FileDesc, _ : Exclusive) -> Result<Self, Error> {
+        Ok(FileId)
+    }
+    pub fn take_lock(&self) {}
+    pub fn try_take_lock(&self) -> bool { true }
+    pub fn release_lock(&self) {}
+}

--- a/src/nil_fileid.rs
+++ b/src/nil_fileid.rs
@@ -1,0 +1,9 @@
+
+use crate::Error;
+use crate::sys::FileDesc;
+
+pub type FileId = ();
+pub fn get_id(_: FileDesc) -> Result<FileId, Error> { Ok(()) }
+pub fn take_lock(_: FileId) {}
+pub fn try_take_lock(_: FileId) -> bool { true }
+pub fn release_lock(_: FileId) {}

--- a/src/unix_fileid.rs
+++ b/src/unix_fileid.rs
@@ -1,0 +1,59 @@
+
+use crate::Error;
+use crate::sys::FileDesc;
+
+use std::{sync::{Arc, Mutex, Condvar}, collections::{HashMap, hash_map::Entry}};
+use once_cell::sync::Lazy;
+
+pub type FileId = (u64, u64);
+
+static HELD_LOCKS: Lazy<Mutex<HashMap<FileId, Arc<Condvar>>>> = Lazy::new(|| {
+    Mutex::new(HashMap::new())
+});
+
+pub fn get_id(fd: FileDesc) -> Result<FileId, Error> {
+    unsafe {
+        let mut stat: libc::stat = std::mem::zeroed();
+        if libc::fstat(fd, &mut stat) >= 0 {
+            Ok((stat.st_dev as u64, stat.st_ino as u64))
+        } else {
+            Err(Error::last_os_error())
+        }
+    }
+}
+
+pub fn take_lock(id: FileId) {
+    let mut cvar: Option<Arc<Condvar>> = None;
+    let mut held = HELD_LOCKS.lock().unwrap();
+    loop {
+        match held.entry(id) {
+            Entry::Vacant(e) => {
+                e.insert(cvar.unwrap_or_else(|| Arc::new(Condvar::new())));
+                return;
+            }
+            Entry::Occupied(ref e) => {
+                let cv = Arc::clone(e.get());
+                held = cv.wait(held).unwrap(); // releases lock on held while waiting.
+                cvar = Some(cv);
+            }
+        }
+    }
+}
+
+pub fn try_take_lock(id: FileId) -> bool{
+    let mut held = HELD_LOCKS.lock().unwrap();
+    if let Entry::Vacant(e) = held.entry(id) {
+        e.insert(Arc::new(Condvar::new()));
+        true
+    } else {
+        false
+    }
+}
+
+pub fn release_lock(id: FileId) {
+    let mut held = HELD_LOCKS.lock().unwrap();
+    if let Some(cvar) = held.remove(&id) {
+        cvar.notify_one();
+    }
+}
+


### PR DESCRIPTION
This patch tries to gives Unix the same behavior as is documented for
Windows when opening multiple handles to the same file: if any other
Lockfile currently is locking the same file, then other Lockfiles
will block when trying to lock it.

It works by using an internal HashMap to determine which files are
locked and which are not.  (We identify files by a combination of
st_dev and st_ino).  This logic is behind a new feature,
`multilock`, which depends on `std` and `once_cell`.

I'm submitting this patch for feedback, to ask if the general
approach looks like something that could be accepted. Please don't
merge it as-is: it needs tests and documentation.