### PR TITLE
fix compilation on 32b Android

### DIFF
--- a/src/unix_fileid.rs
+++ b/src/unix_fileid.rs
@@ -7,7 +7,10 @@ use std::{
     sync::{Arc, Condvar, Mutex},
 };
 
+#[cfg(not(target_os="android"))]
 type RawFileId = (libc::dev_t, libc::ino_t);
+#[cfg(target_os="android")]
+type RawFileId = (libc::c_ulonglong, libc::c_ulonglong);
 
 static HELD_LOCKS: Lazy<Mutex<HashMap<RawFileId, Arc<Condvar>>>> =
     Lazy::new(|| Mutex::new(HashMap::new()));


### PR DESCRIPTION
for some reasons, `st_dev` and `st_ino` are not `dev_t`/`dev_ino` on Android, and this break compilation on 32bit Android when the feature `multilock` is enabled.

This PR add support for the following targets (without breaking already functioning ones):
- arm-linux-androideabi
- armv7-linux-androideabi
- i686-linux-android
- thumbv7neon-linux-androideabi

Would it be possible to do a release after this change, so it is made available by crates-io?