### PR TITLE
Make `OsString` `Send`

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -99,6 +99,8 @@ pub struct OsString {
     len: usize,
 }
 
+unsafe impl Send for OsString {}
+
 impl Drop for OsString {
     fn drop(&mut self) {
         let ptr = self.alloc.as_ptr() as *mut libc::c_void;

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -143,6 +143,8 @@ pub struct OsString {
     len: usize,
 }
 
+unsafe impl Send for OsString {}
+
 impl Drop for OsString {
     fn drop(&mut self) {
         let ptr = self.alloc.as_ptr() as LPVOID;


### PR DESCRIPTION
I made a simple wrapper around a lockfile to run everything using tokio's blocking threadpool, but I needed to make `OsString` `Send` so that I can send the path to the threadpool when opening a lockfile.  I didn't see any behaviors in each platform's `OsString` type that would make it not `Send`. The alternative to this PR would be forcing the use of another buffer type like `PathBuf`, but I feel like manually implementing `Send` is the cleaner solution.