### PR TITLE
changing try_lock to match Mutex standard

### DIFF
--- a/examples/try_lock.rs
+++ b/examples/try_lock.rs
@@ -18,11 +18,8 @@ fn main() -> Result<(), fslock::Error> {
 
     let mut lockfile = LockFile::open(&path)?;
 
-    if lockfile.try_lock()? {
-        println!("SUCCESS");
-    } else {
-        println!("FAILURE");
-    }
+    lockfile.try_lock()?;
+    println!("SUCCESS");
 
     Ok(())
 }

--- a/examples/try_lock_with_pid.rs
+++ b/examples/try_lock_with_pid.rs
@@ -18,17 +18,14 @@ fn main() -> Result<(), fslock::Error> {
 
     let mut lockfile = LockFile::open(&path)?;
 
-    if lockfile.try_lock_with_pid()? {
-        let content_a = read_to_string(&path)?;
-        let content_b = read_to_string(&path)?;
-        assert!(content_a.trim().len() > 0);
-        assert!(content_a.trim().chars().all(|ch| ch.is_ascii_digit()));
-        assert_eq!(content_a, content_b);
+    lockfile.try_lock_with_pid()?;
+    let content_a = read_to_string(&path)?;
+    let content_b = read_to_string(&path)?;
+    assert!(content_a.trim().len() > 0);
+    assert!(content_a.trim().chars().all(|ch| ch.is_ascii_digit()));
+    assert_eq!(content_a, content_b);
 
-        println!("{}", content_a);
-    } else {
-        println!("FAILURE");
-    }
+    println!("{}", content_a);
 
     Ok(())
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,10 +233,10 @@ impl LockFile {
     /// use fslock::LockFile;
     ///
     /// let mut file = LockFile::open("testfiles/attempt.lock")?;
-    /// if file.try_lock()? {
-    ///     do_stuff();
-    ///     file.unlock()?;
-    /// }
+    /// file.try_lock()?;
+    /// do_stuff();
+    /// file.unlock()?;
+    ///
     ///
     /// # Ok(())
     /// # }
@@ -258,15 +258,11 @@ impl LockFile {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn try_lock(&mut self) -> Result<bool, Error> {
+    pub fn try_lock(&mut self) -> Result<(), Error> {
         if self.locked {
             panic!("Cannot lock if already owning a lock");
         }
-        let lock_result = sys::try_lock(self.desc);
-        if let Ok(true) = lock_result {
-            self.locked = true;
-        }
-        lock_result
+        sys::try_lock(self.desc)
     }
 
     /// Locks this file and writes this process's PID into the file, which will
@@ -319,19 +315,15 @@ impl LockFile {
     /// # Ok(())
     /// # }
     /// ```
-    pub fn try_lock_with_pid(&mut self) -> Result<bool, Error> {
-        match self.try_lock() {
-            Ok(true) => (),
-            Ok(false) => return Ok(false),
-            Err(error) => return Err(error),
-        }
+    pub fn try_lock_with_pid(&mut self) -> Result<(), Error> {
+        self.try_lock()?;
 
         let result = sys::truncate(self.desc)
             .and_then(|_| writeln!(fmt::Writer(self.desc), "{}", sys::pid()));
         if result.is_err() {
             let _ = self.unlock();
         }
-        result.map(|_| true)
+        result.map(|_| ())
     }
 
     /// Returns whether this file handle owns the lock.

--- a/src/test.rs
+++ b/src/test.rs
@@ -27,7 +27,7 @@ fn try_read_pid() -> Result<(), Error> {
 
     let path = "testfiles/try_read_pid.lock";
     let mut file = LockFile::open(path)?;
-    assert!(file.try_lock_with_pid()?);
+    file.try_lock_with_pid()?;
 
     let content_a = read_to_string(path)?;
     let content_b = read_to_string(path)?;
@@ -123,7 +123,7 @@ fn other_process_pid() -> Result<(), Error> {
 
     let path = "testfiles/other_process_pid.lock";
     let mut file = LockFile::open(path)?;
-    assert!(file.try_lock_with_pid()?);
+    file.try_lock_with_pid()?;
 
     let content = read_to_string(path)?;
     assert!(content.trim().len() > 0);
@@ -139,7 +139,7 @@ fn other_process_pid() -> Result<(), Error> {
     let child_content = read_to_string(path)?;
     assert!(child_content.trim().len() == 0);
 
-    assert!(file.try_lock_with_pid()?);
+    file.try_lock_with_pid()?;
 
     let content_again = read_to_string(path)?;
     assert_eq!(content_again, content);

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -330,17 +330,13 @@ pub fn lock(fd: FileDesc) -> Result<(), Error> {
 }
 
 /// Tries to lock a file but returns as soon as possible if already locked.
-pub fn try_lock(fd: FileDesc) -> Result<bool, Error> {
+pub fn try_lock(fd: FileDesc) -> Result<(), Error> {
     let res = unsafe { libc::flock(fd, libc::LOCK_EX | libc::LOCK_NB) };
     if res >= 0 {
-        Ok(true)
+        Ok(())
     } else {
         let err = errno();
-        if err == libc::EWOULDBLOCK || err == libc::EINTR {
-            Ok(false)
-        } else {
-            Err(Error::from_raw_os_error(err as i32))
-        }
+        Err(Error::from_raw_os_error(err as i32))
     }
 }
 


### PR DESCRIPTION
Changes try_lock from a Result<bool> to just a Result<()>. This better matches the standard library (see [mutex](https://doc.rust-lang.org/std/sync/struct.Mutex.html#method.try_lock) as an example).

I find this to be much more intuitive and inline with the current rust standards.