### PR TITLE
Fix 'undefined behaviors' detected by MIRI

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -163,3 +163,20 @@ jobs:
         with:
           command: test
           args: --no-default-features
+
+  miri:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        # Miri requires nightly Rust
+        toolchain: nightly
+        override: true
+        components: miri
+    - name: Run Miri
+      run: cargo miri test
+      env:
+        MIRIFLAGS: -Zmiri-disable-isolation

--- a/src/test.rs
+++ b/src/test.rs
@@ -106,6 +106,7 @@ fn check_try_lock_with_pid_example(
 
 #[cfg(feature = "std")]
 #[test]
+#[cfg_attr(miri, ignore)]
 fn other_process() -> Result<(), Error> {
     let path = "testfiles/other_process.lock";
     let mut file = LockFile::open(path)?;
@@ -118,6 +119,7 @@ fn other_process() -> Result<(), Error> {
 
 #[cfg(feature = "std")]
 #[test]
+#[cfg_attr(miri, ignore)]
 fn other_process_pid() -> Result<(), Error> {
     use std::fs::read_to_string;
 
@@ -162,6 +164,7 @@ fn other_process_pid() -> Result<(), Error> {
 
 #[cfg(feature = "std")]
 #[test]
+#[cfg_attr(miri, ignore)]
 fn other_process_but_curr_reads() -> Result<(), Error> {
     use std::fs::read_to_string;
 


### PR DESCRIPTION
I found the following error on the Miri report when I was running Miri on something else.

The shortest fix is to make the fields cover the null byte as well. I didn't find any APIs that exposed bytes to the user so this change should be backwards compatible.

```
test test::read_pid ... error: Undefined Behavior: attempting a read access using <294210> at alloc102399[0x17], but that tag does not exist in the borrow stack for this location
   --> src/unix.rs:266:9
    |
266 | /         libc::open(
267 | |             path.bytes.as_ptr(),
268 | |             libc::O_RDWR | libc::O_CLOEXEC | libc::O_CREAT,
269 | |             (libc::S_IRUSR | libc::S_IWUSR | libc::S_IRGRP | libc::S_...
270 | |                 as libc::c_int,
271 | |         )
    | |         ^
    | |         |
    | |_________attempting a read access using <294210> at alloc102399[0x17], but that tag does not exist in the borrow stack for this location
    |           this error occurs as part of an access at alloc102399[0x17..0x18]
    |
    = help: this indicates a potential bug in the program: it performed an invalid operation, but the Stacked Borrows rules it violated are still experimental
    = help: see https://github.com/rust-lang/unsafe-code-guidelines/blob/master/wip/stacked-borrows.md for further information
help: <294210> was created by a SharedReadOnly retag at offsets [0x0..0x17]
   --> src/unix.rs:267:13
    |
267 |             path.bytes.as_ptr(),
    |             ^^^^^^^^^^^^^^^^^^^
    = note: BACKTRACE (of the first span) on thread `test::read_pid`:
    = note: inside `unix::open` at src/unix.rs:266:9: 271:10
note: inside `LockFile::open::<str>`
   --> src/lib.rs:123:20
    |
123 |         let desc = sys::open(path.as_ref())?;
```

